### PR TITLE
Fixed infinite loop

### DIFF
--- a/RemoteBukkitPlugin/src/main/java/me/escortkeel/remotebukkit/ConnectionHandler.java
+++ b/RemoteBukkitPlugin/src/main/java/me/escortkeel/remotebukkit/ConnectionHandler.java
@@ -66,6 +66,7 @@ public class ConnectionHandler extends Thread {
                     }
                 });
             } catch (IOException ex) {
+                break;
             }
         }
 


### PR DESCRIPTION
The while loop in ConnectionHandler was incorrectly handling null values from in.readLine(). Since assigning a null value to a final variable throws an exception, which is caught but ignored, the while loop continues on forever.
This has the effect of creating massive CPU usage whenever a remote console session is closed.
